### PR TITLE
create tooltip component

### DIFF
--- a/src/components/shared/TooltipGray.js
+++ b/src/components/shared/TooltipGray.js
@@ -1,0 +1,25 @@
+import React from 'react'
+
+export const Tooltip = (props) => {
+    return (
+        <span class="
+        tooltip
+        px-2 py-1
+        bg-gray-700
+        text-white text-sm
+        rounded shadow-xl
+        ">
+            { props.children }
+        </span>
+    )
+}
+
+{/*
+    // HOW TO USE TOOL TIPS
+    <div class=".... has-tooltip">
+        ..usual content..
+        <TooltipGray>
+            ..message here..
+        </TooltipGray>
+    </div>
+*/}

--- a/src/components/shared/TooltipGray.js
+++ b/src/components/shared/TooltipGray.js
@@ -1,6 +1,6 @@
 import React from 'react'
 
-export const Tooltip = (props) => {
+export const TooltipGray = ({ children }) => {
     return (
         <span class="
         tooltip
@@ -9,7 +9,7 @@ export const Tooltip = (props) => {
         text-white text-sm
         rounded shadow-xl
         ">
-            { props.children }
+            { children }
         </span>
     )
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,3 +1,17 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* tool tip setup */
+/* https://play.tailwindcss.com/2eBipAu8Bt */
+@layer components {
+    .tooltip {
+        /* @apply invisible hidden absolute; */
+        @apply invisible absolute;
+    }
+
+    .has-tooltip:hover .tooltip {
+        /* @apply visible block z-50; */
+        @apply visible z-50;
+    }
+}


### PR DESCRIPTION
Created TooltipGray component
- instructions can be found commented @ /components/shared/TooltipGray.js

In the future
- create new variations of the tooltip (e.g. purple tooltip, white tooltip, etc.)